### PR TITLE
PWX-26770 Sample blueprint now doesn't have AWS marketplace flag set t…

### DIFF
--- a/blueprint/getting_started/main.tf
+++ b/blueprint/getting_started/main.tf
@@ -127,7 +127,6 @@ module "eks_blueprints_kubernetes_addons" {
   portworx_chart_values               ={ 
     awsAccessKeyId = var.aws_access_key_id
     awsSecretAccessKey = var.aws_secret_access_key
-    useAWSMarketplace  = true
     # other custom values
   }
   


### PR DESCRIPTION
…o true by default

Signed-off-by: pragrawal10 <pragrawal@purestorage>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

The sample blueprints had AWS marketplace licence flag set to true by default. This PR remove that.

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

