### PR TITLE
fix: temporarily unpin module version for terraform 1.3 support

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon"{
-  source = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.7.0"
+  source = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon"
   addon_context        = var.addon_context
   set_values           = local.set_values
   helm_config          = local.helm_config

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,6 @@
 module "helm_addon"{
   source = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon"
+
   addon_context        = var.addon_context
   set_values           = local.set_values
   helm_config          = local.helm_config

--- a/main.tf
+++ b/main.tf
@@ -1,8 +1,8 @@
 module "helm_addon"{
   source = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon"
 
-  addon_context        = var.addon_context
-  set_values           = local.set_values
-  helm_config          = local.helm_config
-  irsa_config          = local.irsa_config
+  addon_context = var.addon_context
+  set_values    = local.set_values
+  helm_config   = local.helm_config
+  irsa_config   = local.irsa_config
 }


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
We need to remove the module pinning for the time being to resolve issue with support for terraform 1.3 version. We are planning on moving the kubernetes-addons/helm-addon module to a separate repo to remove this cyclical dependency from future versions. We will open another PR at that point.

**Which issue(s) this PR fixes** (optional)
Closes #
Fixes https://github.com/aws-ia/terraform-aws-eks-blueprints/actions/runs/3221402990/jobs/5269295066

**Special notes for your reviewer**:

